### PR TITLE
Install discord and make codespell and mypy mandatory tests

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -9,11 +9,11 @@ jobs:
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade
       - run: bandit -r . || true
       - run: black --check . || true
-      - run: codespell --quiet-level=2 || true  # --ignore-words-list="" --skip=""
+      - run: codespell --quiet-level=2  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --check-only --profile black . || true
-      - run: pip install -r requirements.txt || true
-      - run: mypy --ignore-missing-imports . || true
+      - run: pip install discord  # -r requirements.txt || true
+      - run: mypy --ignore-missing-imports .
       - run: pytest . || true
       - run: pytest --doctest-modules . || true
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -12,7 +12,7 @@ jobs:
       - run: codespell --quiet-level=2  # --ignore-words-list="" --skip=""
       - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
       - run: isort --check-only --profile black . || true
-      - run: pip install discord  # -r requirements.txt || true
+      - run: pip install -r requirements.txt
       - run: mypy --ignore-missing-imports .
       - run: pytest . || true
       - run: pytest --doctest-modules . || true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+discord
+timeago

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 discord
+discord-pretty-help
 timeago


### PR DESCRIPTION
1. Pip install discord
2. Remove the `|| true` from codespell to make misspelled words fail the build
3. Remove the `|| true` from mypy to make type hint errors fail the build

### Next step:
It would be good to remove the `|| true` from bandit and fix the code that it is complaining about because of it can hide bugs https://realpython.com/the-most-diabolical-python-antipattern